### PR TITLE
Integrate JFXtras Agenda example with Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>Prueba_jfxtras</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Prueba JFXtras</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.JFXtras</groupId>
+            <artifactId>jfxtras-styles</artifactId>
+            <version>8.6.14</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.JFXtras</groupId>
+            <artifactId>jfxtras-agenda</artifactId>
+            <version>8.6.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>21</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <configuration>
+                    <mainClass>org.example.jfxtrasdemo.AgendaApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/org/example/jfxtrasdemo/AgendaApp.java
+++ b/src/main/java/org/example/jfxtrasdemo/AgendaApp.java
@@ -1,0 +1,33 @@
+package org.example.jfxtrasdemo;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import jfxtras.scene.control.agenda.Agenda;
+
+import java.time.LocalDateTime;
+
+public class AgendaApp extends Application {
+
+    @Override
+    public void start(Stage primaryStage) {
+        Agenda agenda = new Agenda();
+
+        Agenda.Appointment appointment = new Agenda.AppointmentImplLocal()
+                .withStartLocalDateTime(LocalDateTime.now().plusHours(1))
+                .withEndLocalDateTime(LocalDateTime.now().plusHours(2))
+                .withSummary("Cita con paciente")
+                .withDescription("Consulta de revisión");
+
+        agenda.appointments().add(appointment);
+
+        Scene scene = new Scene(agenda, 800, 600);
+        primaryStage.setTitle("Agenda de Pacientes");
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}


### PR DESCRIPTION
## Summary
- add Maven `pom.xml` including JitPack repository and JFXtras dependencies
- implement a simple `AgendaApp` JavaFX example for patient appointments

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d8d2fe5e4832486fe0df5a703ff11